### PR TITLE
Implementing both 128 and 256 aead-aes-gcm

### DIFF
--- a/lib/net/ssh/transport/aead_aes_gcm.rb
+++ b/lib/net/ssh/transport/aead_aes_gcm.rb
@@ -1,0 +1,60 @@
+require 'openssl'
+require 'delegate'
+
+module Net::SSH::Transport
+  # :nodoc:
+  # Ruby implementation of AEAD Aes-GCM Mode
+  # for Block Ciphers. See RFC5647 for details.
+  # The main purpose is the implementation of the GCM iv increment
+  module AEADAESGCM
+    def self.extended(orig)
+      orig.instance_eval do
+        @iv = { fixed: nil, invocation_ctr: nil }
+        orig.padding = 0
+
+        singleton_class.send(:alias_method, :_update, :update)
+        singleton_class.send(:private, :_update)
+        singleton_class.send(:undef_method, :update)
+
+        def self.block_size
+          16
+        end
+
+        def iv_len
+          12
+        end
+
+        def iv=(iv_s)
+          if @iv[:fixed].nil?
+            @iv[:fixed] = iv_s[0...4]
+            @iv[:invocation_ctr] = iv_s[4..12]
+          end
+          super(iv_s)
+        end
+
+        def incr_iv
+          return if @iv[:fixed].nil?
+
+          @iv[:invocation_ctr] = [(@iv[:invocation_ctr].unpack1('B*').to_i(2) + 1)].pack('Q>*')
+          self.iv = "#{@iv[:fixed]}#{@iv[:invocation_ctr]}"
+        end
+
+        def padding=(pad)
+          # DO NOTHING (always 0)
+        end
+
+        def reset
+          super
+        end
+
+        def final
+          super
+        end
+
+        def update(data)
+          super(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/net/ssh/transport/cipher_factory.rb
+++ b/lib/net/ssh/transport/cipher_factory.rb
@@ -1,10 +1,11 @@
 require 'openssl'
 require 'net/ssh/transport/ctr.rb'
+require 'net/ssh/transport/aead_aes_gcm'
 require 'net/ssh/transport/key_expander'
 require 'net/ssh/transport/identity_cipher'
 
-module Net 
-  module SSH 
+module Net
+  module SSH
     module Transport
 
       # Implements a factory of OpenSSL cipher algorithms.
@@ -26,6 +27,8 @@ module Net
           'aes192-ctr'                  => 'aes-192-ctr',
           'aes128-ctr'                  => 'aes-128-ctr',
           'cast128-ctr'                 => 'cast5-ecb',
+          "aes256-gcm@openssh.com"      => "aes-256-gcm",
+          "aes128-gcm@openssh.com"      => "aes-128-gcm",
 
           'none'                        => 'none'
         }
@@ -37,7 +40,7 @@ module Net
           return true if ossl_name == "none"
           return OpenSSL::Cipher.ciphers.include?(ossl_name)
         end
-    
+
         # Retrieves a new instance of the named algorithm. The new instance
         # will be initialized using an iv and key generated from the given
         # iv, key, shared, hash and digester values. Additionally, the
@@ -47,11 +50,11 @@ module Net
           ossl_name = SSH_TO_OSSL[name] or raise NotImplementedError, "unimplemented cipher `#{name}'"
           return IdentityCipher if ossl_name == "none"
           cipher = OpenSSL::Cipher.new(ossl_name)
-    
+
           cipher.send(options[:encrypt] ? :encrypt : :decrypt)
-    
+
           cipher.padding = 0
-    
+
           if name =~ /-ctr(@openssh.org)?$/
             if ossl_name !~ /-ctr/
               cipher.extend(Net::SSH::Transport::CTR)
@@ -59,15 +62,20 @@ module Net
               cipher = Net::SSH::Transport::OpenSSLAESCTR.new(cipher)
             end
           end
+
+          if name =~ /-gcm/
+            cipher.extend(Net::SSH::Transport::AEADAESGCM)
+            cipher.send(options[:encrypt] ? :encrypt : :decrypt)
+          end
           cipher.iv = Net::SSH::Transport::KeyExpander.expand_key(cipher.iv_len, options[:iv], options)
-    
+
           key_len = cipher.key_len
           cipher.key_len = key_len
           cipher.key = Net::SSH::Transport::KeyExpander.expand_key(key_len, options[:key], options)
-    
+
           return cipher
         end
-    
+
         # Returns a two-element array containing the [ key-length,
         # block-size ] for the named cipher algorithm. If the cipher
         # algorithm is unknown, or is "none", 0 is returned for both elements
@@ -82,7 +90,7 @@ module Net
             cipher = OpenSSL::Cipher.new(ossl_name)
             key_len = cipher.key_len
             cipher.key_len = key_len
-    
+
             block_size =
               case ossl_name
               when /\-ctr/
@@ -90,7 +98,7 @@ module Net
               else
                 cipher.block_size
               end
-    
+
             result = [key_len, block_size]
             result << cipher.iv_len if options[:iv_len]
           end

--- a/lib/net/ssh/transport/hmac.rb
+++ b/lib/net/ssh/transport/hmac.rb
@@ -1,4 +1,6 @@
 require 'net/ssh/transport/key_expander'
+require 'net/ssh/transport/hmac/aead_aes128_gcm'
+require 'net/ssh/transport/hmac/aead_aes256_gcm'
 require 'net/ssh/transport/hmac/md5'
 require 'net/ssh/transport/hmac/md5_96'
 require 'net/ssh/transport/hmac/sha1'
@@ -29,6 +31,8 @@ module Net::SSH::Transport::HMAC
     'hmac-sha2-512-etm@openssh.com' => SHA2_512_Etm,
     'hmac-ripemd160'                => RIPEMD160,
     'hmac-ripemd160@openssh.com'    => RIPEMD160,
+    'aes128-gcm@openssh.com'        => Aes128gcm,
+    'aes256-gcm@openssh.com'        => Aes256gcm,
     'none'                          => None
   }
 

--- a/lib/net/ssh/transport/hmac/abstract.rb
+++ b/lib/net/ssh/transport/hmac/abstract.rb
@@ -9,6 +9,18 @@ module Net
         # The base class of all OpenSSL-based HMAC algorithm wrappers.
         class Abstract
           class <<self
+            def aead(*v)
+              @aead = false if !defined?(@aead)
+              if v.empty?
+                @aead = superclass.aead if @aead.nil? && superclass.respond_to?(:aead)
+                return @aead
+              elsif v.length == 1
+                @aead = v.first
+              else
+                raise ArgumentError, "wrong number of arguments (#{v.length} for 1)"
+              end
+            end
+
             def etm(*v)
               @etm = false if !defined?(@etm)
               if v.empty?
@@ -56,6 +68,10 @@ module Net
                 raise ArgumentError, "wrong number of arguments (#{v.length} for 1)"
               end
             end
+          end
+
+          def aead
+            self.class.aead
           end
 
           def etm

--- a/lib/net/ssh/transport/hmac/aead_aes128_gcm.rb
+++ b/lib/net/ssh/transport/hmac/aead_aes128_gcm.rb
@@ -1,0 +1,11 @@
+require 'net/ssh/transport/hmac/abstract'
+
+module Net::SSH::Transport::HMAC
+  # The SHA-512 Encrypt-Then-Mac HMAC algorithm. This has a mac and
+  # key length of 64, and uses the SHA-512 digest algorithm.
+  class Aes128gcm < Abstract
+    aead         true
+    mac_length   16
+    key_length   16
+  end
+end

--- a/lib/net/ssh/transport/hmac/aead_aes256_gcm.rb
+++ b/lib/net/ssh/transport/hmac/aead_aes256_gcm.rb
@@ -1,0 +1,11 @@
+require 'net/ssh/transport/hmac/abstract'
+
+module Net::SSH::Transport::HMAC
+  # The SHA-512 Encrypt-Then-Mac HMAC algorithm. This has a mac and
+  # key length of 64, and uses the SHA-512 digest algorithm.
+  class Aes256gcm < Abstract
+    aead         true
+    mac_length   16
+    key_length   32
+  end
+end

--- a/lib/net/ssh/transport/packet_stream.rb
+++ b/lib/net/ssh/transport/packet_stream.rb
@@ -13,7 +13,7 @@ module Net
       # module. It adds SSH encryption, compression, and packet validation, as
       # per the SSH2 protocol. It also adds an abstraction for polling packets,
       # to allow for both blocking and non-blocking reads.
-      module PacketStream
+      module PacketStream # rubocop:disable Metrics/ModuleLength
         PROXY_COMMAND_HOST_IP = '<no hostip for proxy command>'.freeze
 
         include BufferedIo
@@ -124,18 +124,18 @@ module Net
         # Enqueues a packet to be sent, but does not immediately send the packet.
         # The given payload is pre-processed according to the algorithms specified
         # in the client state (compression, cipher, and hmac).
-        def enqueue_packet(payload)
+        def enqueue_packet(payload) # rubocop:disable Metrics/AbcSize
           # try to compress the packet
           payload = client.compress(payload)
 
           # the length of the packet, minus the padding
-          actual_length = (client.hmac.etm ? 0 : 4) + payload.bytesize + 1
+          mac_len = client.hmac.etm || client.hmac.aead ? 0 : 4
+          actual_length = payload.bytesize + mac_len + 1
 
           # compute the padding length
           padding_length = client.block_size - (actual_length % client.block_size)
           padding_length += client.block_size if padding_length < 4
 
-          # compute the packet length (sans the length field itself)
           packet_length = payload.bytesize + padding_length + 1
 
           if packet_length < 16
@@ -162,6 +162,21 @@ module Net
             mac = client.hmac.digest([client.sequence_number, mac_data].pack("NA*"))
 
             message = mac_data + mac
+          elsif client.hmac.aead
+            # Details of this implementation can be found in RFC 5647
+
+            unencrypted_data = [padding_length, payload, padding].pack("CA*A*")
+
+            # Despite SSH spec, when using AEAD encryption, packet_length is not ciphered. It is transported as identity,
+            # and added in the auth_data. See RFC 5647 7.3
+            client.cipher.auth_data = [packet_length].pack('N')
+            encrypted_data = client.update_cipher(unencrypted_data)
+            encrypted_data << client.final_cipher
+
+            # For SSH, GCM auth_tag acts as MAC
+            mac = client.auth_tag
+
+            message = [packet_length].pack("N") + encrypted_data + [mac].pack("A*")
           else
             unencrypted_data = [packet_length, padding_length, payload, padding].pack("NCA*A*")
 
@@ -217,11 +232,12 @@ module Net
         # new Packet object.
         # rubocop:disable Metrics/AbcSize
         def poll_next_packet
-          aad_length = server.hmac.etm ? 4 : 0
+          aad_length = server.hmac.etm || server.hmac.aead ? 4 : 0
 
           if @packet.nil?
             minimum = server.block_size < 4 ? 4 : server.block_size
             return nil if available < minimum + aad_length
+
             data = read_available(minimum + aad_length)
 
             # decipher it
@@ -229,6 +245,11 @@ module Net
               @packet_length = data.unpack("N").first
               @mac_data = data
               @packet = Net::SSH::Buffer.new(server.update_cipher(data[aad_length..-1]))
+            elsif server.hmac.aead
+              # In order to decipher data, we need to extract the fixed 4 bytes packet length...
+              @packet_length = data.unpack("N").first
+              # ...so data payload data is remaining bytes
+              @packet = Net::SSH::Buffer.new(data[4..])
             else
               @packet = Net::SSH::Buffer.new(server.update_cipher(data))
               @packet_length = @packet.read_long
@@ -243,26 +264,38 @@ module Net
           if need > 0
             # read the remainder of the packet and decrypt it.
             data = read_available(need)
-            @mac_data += data if server.hmac.etm
-            @packet.append(server.update_cipher(data))
+            if server.hmac.aead
+              @packet.append(data)
+            else
+              @mac_data += data if server.hmac.etm
+              @packet.append(server.update_cipher(data))
+            end
           end
 
           # get the hmac from the tail of the packet (if one exists), and
           # then validate it.
           real_hmac = read_available(server.hmac.mac_length) || ""
 
-          @packet.append(server.final_cipher)
-          padding_length = @packet.read_byte
+          if server.hmac.aead
+            payload_length = [@packet_length].pack('N')
+            server.cipher.auth_tag = real_hmac.to_s
+            server.cipher.auth_data = payload_length
+            payload = server.cipher.update(@packet.to_s) + server.final_cipher
+            padding_length = payload[0].unpack('C').first.to_i
+            payload = payload[1..@packet_length - padding_length - 1]
+          else
+            @packet.append(server.final_cipher)
+            padding_length = @packet.read_byte
 
-          payload = @packet.read(@packet_length - padding_length - 1)
+            payload = @packet.read(@packet_length - padding_length - 1)
 
-          my_computed_hmac = if server.hmac.etm
-                               server.hmac.digest([server.sequence_number, @mac_data].pack("NA*"))
-                             else
-                               server.hmac.digest([server.sequence_number, @packet.content].pack("NA*"))
-                             end
-          raise Net::SSH::Exception, "corrupted hmac detected #{server.hmac.class}" if real_hmac != my_computed_hmac
-
+            my_computed_hmac = if server.hmac.etm
+                                 server.hmac.digest([server.sequence_number, @mac_data].pack("NA*"))
+                               else
+                                 server.hmac.digest([server.sequence_number, @packet.content].pack("NA*"))
+                               end
+            raise Net::SSH::Exception, "corrupted hmac detected #{server.hmac.class}" if real_hmac != my_computed_hmac
+          end
           # try to decompress the payload, in case compression is active
           payload = server.decompress(payload)
 

--- a/lib/net/ssh/transport/state.rb
+++ b/lib/net/ssh/transport/state.rb
@@ -2,8 +2,8 @@ require 'zlib'
 require 'net/ssh/transport/cipher_factory'
 require 'net/ssh/transport/hmac'
 
-module Net 
-  module SSH 
+module Net
+  module SSH
     module Transport
 
       # Encapsulates state information about one end of an SSH connection. Such
@@ -14,46 +14,46 @@ module Net
       class State
         # The socket object that owns this state object.
         attr_reader :socket
-    
+
         # The next packet sequence number for this socket endpoint.
         attr_reader :sequence_number
-    
+
         # The hmac algorithm in use for this endpoint.
         attr_reader :hmac
-    
+
         # The compression algorithm in use for this endpoint.
         attr_reader :compression
-    
+
         # The compression level to use when compressing data (or nil, for the default).
         attr_reader :compression_level
-    
+
         # The number of packets processed since the last call to #reset!
         attr_reader :packets
-    
+
         # The number of data blocks processed since the last call to #reset!
         attr_reader :blocks
-    
+
         # The cipher algorithm in use for this socket endpoint.
         attr_reader :cipher
-    
+
         # The block size for the cipher
         attr_reader :block_size
-    
+
         # The role that this state plays (either :client or :server)
         attr_reader :role
-    
+
         # The maximum number of packets that this endpoint wants to process before
         # needing a rekey.
         attr_accessor :max_packets
-    
+
         # The maximum number of blocks that this endpoint wants to process before
         # needing a rekey.
         attr_accessor :max_blocks
-    
+
         # The user-specified maximum number of bytes that this endpoint ought to
         # process before needing a rekey.
         attr_accessor :rekey_limit
-    
+
         # Creates a new state object, belonging to the given socket. Initializes
         # the algorithms to "none".
         def initialize(socket, role)
@@ -67,7 +67,7 @@ module Net
           @compressor = @decompressor = nil
           @next_iv = ""
         end
-    
+
         # A convenience method for quickly setting multiple values in a single
         # command.
         def set(values)
@@ -76,19 +76,23 @@ module Net
           end
           reset!
         end
-    
+
         def update_cipher(data)
           result = cipher.update(data)
-          update_next_iv(role == :client ? result : data)
+          update_next_iv(role == :client ? result : data) unless hmac.aead
           return result
         end
-    
+
         def final_cipher
           result = cipher.final
           update_next_iv(role == :client ? result : "", true)
           return result
         end
-    
+
+        def auth_tag
+          hmac.aead ? cipher.auth_tag : ''
+        end
+
         # Increments the counters. The sequence number is incremented (and remapped
         # so it always fits in a 32-bit integer). The number of packets and blocks
         # are also incremented.
@@ -97,18 +101,18 @@ module Net
           @packets += 1
           @blocks += (packet_length + 4) / @block_size
         end
-    
+
         # The compressor object to use when compressing data. This takes into account
         # the desired compression level.
         def compressor
           @compressor ||= Zlib::Deflate.new(compression_level || Zlib::DEFAULT_COMPRESSION)
         end
-    
+
         # The decompressor object to use when decompressing data.
         def decompressor
           @decompressor ||= Zlib::Inflate.new(nil)
         end
-    
+
         # Returns true if data compression/decompression is enabled. This will
         # return true if :standard compression is selected, or if :delayed
         # compression is selected and the :authenticated hint has been received
@@ -116,7 +120,7 @@ module Net
         def compression?
           compression == :standard || (compression == :delayed && socket.hints[:authenticated])
         end
-    
+
         # Compresses the data. If no compression is in effect, this will just return
         # the data unmodified, otherwise it uses #compressor to compress the data.
         def compress(data)
@@ -124,7 +128,7 @@ module Net
           return data unless compression?
           compressor.deflate(data, Zlib::SYNC_FLUSH)
         end
-    
+
         # Deompresses the data. If no compression is in effect, this will just return
         # the data unmodified, otherwise it uses #decompressor to decompress the data.
         def decompress(data)
@@ -132,17 +136,17 @@ module Net
           return data unless compression?
           decompressor.inflate(data)
         end
-    
+
         # Resets the counters on the state object, but leaves the sequence_number
         # unchanged. It also sets defaults for and recomputes the max_packets and
         # max_blocks values.
         def reset!
           @packets = @blocks = 0
-    
+
           @max_packets ||= 1 << 31
-    
+
           @block_size = cipher.block_size
-    
+
           if max_blocks.nil?
             # cargo-culted from openssh. the idea is that "the 2^(blocksize*2)
             # limit is too expensive for 3DES, blowfish, etc., so enforce a 1GB
@@ -152,16 +156,16 @@ module Net
             else
               @max_blocks = (1 << 30) / @block_size
             end
-    
+
             # if a limit on the # of bytes has been given, convert that into a
             # minimum number of blocks processed.
-    
+
             @max_blocks = [@max_blocks, rekey_limit / @block_size].min if rekey_limit
           end
-    
+
           cleanup
         end
-    
+
         # Closes any the compressor and/or decompressor objects that have been
         # instantiated.
         def cleanup
@@ -169,17 +173,17 @@ module Net
             @compressor.finish if !@compressor.finished?
             @compressor.close
           end
-    
+
           if @decompressor
             # we call reset here so that we don't get warnings when we try to
             # close the decompressor
             @decompressor.reset
             @decompressor.close
           end
-    
+
           @compressor = @decompressor = nil
         end
-    
+
         # Returns true if the number of packets processed exceeds the maximum
         # number of packets, or if the number of blocks processed exceeds the
         # maximum number of blocks.
@@ -187,22 +191,26 @@ module Net
           max_packets && packets > max_packets ||
           max_blocks && blocks > max_blocks
         end
-    
+
         private
-    
-        def update_next_iv(data, reset=false)
-          @next_iv << data
-          @next_iv = @next_iv[@next_iv.size - cipher.iv_len..-1]
-    
-          if reset
+
+        def update_next_iv(data, reset = false)
+          if hmac.aead
+            cipher.incr_iv
             cipher.reset
-            cipher.iv = @next_iv
+          else
+            @next_iv << data
+            @next_iv = @next_iv[@next_iv.size - cipher.iv_len..-1]
+
+            if reset
+              cipher.reset
+              cipher.iv = @next_iv
+            end
+
+            return data
           end
-    
-          return data
         end
       end
-
     end
   end
 end

--- a/test/integration/test_aes128_gcm_cipher.rb
+++ b/test/integration/test_aes128_gcm_cipher.rb
@@ -1,0 +1,45 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+require 'timeout'
+
+# see Vagrantfile,playbook for env.
+# we're running as net_ssh_1 user password foo
+# and usually connecting to net_ssh_2 user password foo2pwd
+class TestAes128GcmCipher < NetSSHTest
+  include IntegrationTestHelpers
+
+  def test_with_only_aes_128_gcm_cipher
+    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+    config_lines = config_lines.map do |line|
+      if line =~ /^Ciphers/
+        "##{line}"
+      else
+        line
+      end
+    end
+    config_lines.push("Ciphers aes128-gcm@openssh.com")
+
+    Tempfile.open('empty_kh') do |f|
+      f.close
+      start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+        Timeout.timeout(4) do
+          # We have our own sshd, give it a chance to come up before
+          # listening.
+          ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "aes128-gcm@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+            byebug
+            #assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+            ssh.exec! "echo 'foo'"
+          end
+          assert_equal "foo\n", ret
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep 0.25
+          retry
+        end
+      end
+    end
+  end
+end

--- a/test/integration/test_aes256_gcm_cipher.rb
+++ b/test/integration/test_aes256_gcm_cipher.rb
@@ -1,0 +1,45 @@
+require_relative 'common'
+require 'fileutils'
+require 'tmpdir'
+
+require 'net/ssh'
+
+require 'timeout'
+
+# see Vagrantfile,playbook for env.
+# we're running as net_ssh_1 user password foo
+# and usually connecting to net_ssh_2 user password foo2pwd
+class TestAes256GcmCipher < NetSSHTest
+  include IntegrationTestHelpers
+
+  def test_with_only_aes_128_gcm_cipher
+    config_lines = File.read('/etc/ssh/sshd_config').split("\n")
+    config_lines = config_lines.map do |line|
+      if line =~ /^Ciphers/
+        "##{line}"
+      else
+        line
+      end
+    end
+    config_lines.push("Ciphers aes256-gcm@openssh.com")
+
+    Tempfile.open('empty_kh') do |f|
+      f.close
+      start_sshd_7_or_later(config: config_lines, debug: true) do |_pid, port|
+        Timeout.timeout(4) do
+          # We have our own sshd, give it a chance to come up before
+          # listening.
+          ret = Net::SSH.start("localhost", "net_ssh_1", encryption: "aes256-gcm@openssh.com", password: 'foopwd', port: port, user_known_hosts_file: [f.path], verbose: :debug) do |ssh|
+            byebug
+            #assert_equal ssh.transport.algorithms.kex, "curve25519-sha256"
+            ssh.exec! "echo 'foo'"
+          end
+          assert_equal "foo\n", ret
+        rescue SocketError, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          sleep 0.25
+          retry
+        end
+      end
+    end
+  end
+end

--- a/test/transport/test_aead_aes_gcm.rb
+++ b/test/transport/test_aead_aes_gcm.rb
@@ -1,0 +1,27 @@
+require_relative '../common'
+require 'logger'
+require 'net/ssh/transport/aead_aes_gcm'
+
+module Transport
+  class TestAEADAESGCM < NetSSHTest
+    def gcm_cipher
+      iv = "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
+      Net::SSH::Transport::CipherFactory.get('aes256-gcm@openssh.com',
+                                             iv: iv,
+                                             key: '1' * 32,
+                                             shared: 'toto',
+                                             hash: 'XYZZYXXYZZYX',
+                                             digester: 'none')
+    end
+
+    def test_iv_increment_when_64_bit_long
+      cipher = gcm_cipher
+      cipher.incr_iv
+      assert_equal cipher.instance_variable_get(:@iv), { fixed: "\xFF\xFF\xFF\xFF", invocation_ctr: "\x00\x00\x00\x00\x00\x00\x00\x00" }
+    end
+
+    def test_block_size
+      assert_equal gcm_cipher.block_size, 16
+    end
+  end
+end

--- a/test/transport/test_algorithms.rb
+++ b/test/transport/test_algorithms.rb
@@ -20,8 +20,8 @@ module Transport
     def test_constructor_should_build_default_list_of_preferred_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa], algorithms[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1], algorithms[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr], algorithms[:encryption]
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1], algorithms[:hmac]
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com], algorithms[:encryption]
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com], algorithms[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms[:compression]
       assert_equal %w[], algorithms[:language]
     end
@@ -29,8 +29,8 @@ module Transport
     def test_constructor_should_build_complete_list_of_algorithms_with_append_all_supported_algorithms
       assert_equal ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa ssh-dss], algorithms(append_all_supported_algorithms: true)[:host_key]
       assert_equal x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1 diffie-hellman-group-exchange-sha1 diffie-hellman-group1-sha1], algorithms(append_all_supported_algorithms: true)[:kex]
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none], algorithms(append_all_supported_algorithms: true)[:hmac]
       assert_equal %w[none zlib@openssh.com zlib], algorithms(append_all_supported_algorithms: true)[:compression]
       assert_equal %w[], algorithms[:language]
     end
@@ -110,50 +110,50 @@ module Transport
     end
 
     def test_constructor_with_preferred_encryption_should_put_preferred_encryption_first
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: "aes256-cbc", append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_multiple_preferred_encryption_should_put_all_preferred_encryption_first
-      assert_equal %w[aes256-cbc 3des-cbc idea-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc 3des-cbc idea-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr none], algorithms(encryption: %w[aes256-cbc 3des-cbc idea-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_unrecognized_encryption_should_keep_whats_supported
-      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
+      assert_equal %w[aes256-cbc aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none], algorithms(encryption: %w[bogus aes256-cbc], append_all_supported_algorithms: true)[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_additions
       # There's nothing we can really append to the set since the default algos
       # are frozen so this is really just testing that it doesn't do anything
       # unexpected.
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com aes256-cbc aes192-cbc aes128-cbc rijndael-cbc@lysator.liu.se blowfish-ctr blowfish-cbc cast128-ctr cast128-cbc 3des-ctr 3des-cbc idea-cbc none],
                    algorithms(encryption: %w[+3des-cbc])[:encryption]
     end
 
     def test_constructor_with_preferred_encryption_supports_removals_with_wildcard
-      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr cast128-ctr],
+      assert_equal %w[aes256-ctr aes192-ctr aes128-ctr aes256-gcm@openssh.com aes128-gcm@openssh.com cast128-ctr],
                    algorithms(encryption: %w[-rijndael-cbc@lysator.liu.se -blowfish-* -3des-* -*-cbc -none])[:encryption]
     end
 
     def test_constructor_with_preferred_hmac_should_put_preferred_hmac_first
-      assert_equal %w[hmac-md5-96 hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 none], algorithms(hmac: "hmac-md5-96", append_all_supported_algorithms: true)[:hmac]
+      assert_equal %w[hmac-md5-96 hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 none], algorithms(hmac: "hmac-md5-96", append_all_supported_algorithms: true)[:hmac]
     end
 
     def test_constructor_with_multiple_preferred_hmac_should_put_all_preferred_hmac_first
-      assert_equal %w[hmac-md5-96 hmac-sha1-96 hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 none], algorithms(hmac: %w[hmac-md5-96 hmac-sha1-96], append_all_supported_algorithms: true)[:hmac]
+      assert_equal %w[hmac-md5-96 hmac-sha1-96 hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 none], algorithms(hmac: %w[hmac-md5-96 hmac-sha1-96], append_all_supported_algorithms: true)[:hmac]
     end
 
     def test_constructor_with_unrecognized_hmac_should_ignore_those
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none],
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96 none],
         algorithms(hmac: "unknown hmac-md5-96", append_all_supported_algorithms: true)[:hmac]
     end
 
     def test_constructor_with_preferred_hmac_supports_additions
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96],
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha1 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-sha1-96 hmac-ripemd160 hmac-ripemd160@openssh.com hmac-md5 hmac-md5-96],
                    algorithms(hmac: %w[+hmac-md5-96 -none])[:hmac]
     end
 
     def test_constructor_with_preferred_hmac_supports_removals_with_wildcard
-      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 hmac-sha2-512-96 hmac-sha2-256-96 hmac-ripemd160 hmac-ripemd160@openssh.com],
+      assert_equal %w[hmac-sha2-512-etm@openssh.com hmac-sha2-256-etm@openssh.com hmac-sha2-512 hmac-sha2-256 aes128-gcm@openssh.com aes256-gcm@openssh.com hmac-sha2-512-96 hmac-sha2-256-96 hmac-ripemd160 hmac-ripemd160@openssh.com],
                    algorithms(hmac: %w[-hmac-sha1* -hmac-md5* -none])[:hmac]
     end
 
@@ -408,10 +408,10 @@ module Transport
       assert_equal 16, buffer.read(16).length
       assert_equal options[:kex] || (x25519_kex + ec_kex + %w[diffie-hellman-group-exchange-sha256 diffie-hellman-group14-sha1]).join(','), buffer.read_string
       assert_equal options[:host_key] || (ed_ec_host_keys + %w[ssh-rsa-cert-v01@openssh.com ssh-rsa-cert-v00@openssh.com ssh-rsa]).join(','), buffer.read_string
-      assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
-      assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr', buffer.read_string
-      assert_equal options[:hmac_client] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
-      assert_equal options[:hmac_server] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1', buffer.read_string
+      assert_equal options[:encryption_client] || 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com', buffer.read_string
+      assert_equal options[:encryption_server] || 'aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com', buffer.read_string
+      assert_equal options[:hmac_client] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,aes128-gcm@openssh.com,aes256-gcm@openssh.com', buffer.read_string
+      assert_equal options[:hmac_server] || 'hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1,aes128-gcm@openssh.com,aes256-gcm@openssh.com', buffer.read_string
       assert_equal options[:compression_client] || 'none,zlib@openssh.com,zlib', buffer.read_string
       assert_equal options[:compression_server] || 'none,zlib@openssh.com,zlib', buffer.read_string
       assert_equal options[:language_client] || '', buffer.read_string

--- a/test/transport/test_cipher_factory.rb
+++ b/test/transport/test_cipher_factory.rb
@@ -239,6 +239,17 @@ module Transport
       assert_equal TEXT, decrypt("aes256-ctr", AES256_CTR)
     end
 
+    AES256_GCM = "\xA0\xDC#-\xB4\x010+\aP\x85 \x0E\xD0!\x8D\xB3\xA9\x8A\x92K\x0F\x82?*\xCA[\f\eJ{\x97\a\xB1Z\f\x93\x16\xEF%\xCA\xAC\xE4\x0E\xF6Y\xA9H\xC2\"zsg\xD3\xF69\xF9\xE3-\xCF\t\x1A\xA6\xA4U\xF5w\x89?k\x04\xE2I\xD9\xC4\x03\xD9\x9D~\xF5\xF9\xDE\x04\xC3\xF8\xCC\x9B\xB8&2\xF8B+e\x92\v"
+    AES256_GCM2 = "\xA2d\xE2v\xB6\xC7\xA6}\xAE\xBC'\xEBe\xE2*l\xC1\xFF\x96\xF0\\:\xA4\xCF\xAD\a\xAFW\x90\x1C4\x7F7E\xF4\xDF \xB5\x1C\xB6K\x18s^\f\x96S#7F\x99\xCAP_\x98\xFC\x13\xF5c-\xF2@6\x9Cg\xE8\xF3Q%\xC6\xF5K\xCE\xD7\xB9\xDF\xC5\x04K\xD1\xF2\xB0M\xF0\x9F(\xD8\x05u\xE8\xBA\xAA\x81\xF0nD"
+
+    def test_aes256_gcm_for_encryption
+      assert_equal AES256_GCM, encrypt("aes256-gcm@openssh.com")
+    end
+
+    def test_aes256_gcm_for_encryption2
+      assert_equal [AES256_GCM, AES256_GCM2], encrypt2("aes256-gcm@openssh.com")
+    end
+
     def test_none_for_encryption
       assert_equal TEXT, encrypt("none").strip
     end
@@ -279,7 +290,7 @@ module Transport
 
       cipher.reset
 
-      cipher.iv = "0123456789123456"
+      cipher.iv = "012345678912"
       padding = TEXT2.length % cipher.block_size
       result2 = cipher.update(TEXT2.dup)
       result2 << cipher.update(" " * (cipher.block_size - padding)) if padding > 0

--- a/test/transport/test_packet_stream.rb
+++ b/test/transport/test_packet_stream.rb
@@ -1053,7 +1053,7 @@ module Transport
     end
 
     ciphers = Net::SSH::Transport::CipherFactory::SSH_TO_OSSL.keys
-    hmacs = Net::SSH::Transport::HMAC::MAP.keys
+    hmacs = Net::SSH::Transport::HMAC::MAP.keys - %w[aes256-gcm@openssh.com aes128-gcm@openssh.com]
 
     ciphers.each do |cipher_name|
       unless Net::SSH::Transport::CipherFactory.supported?(cipher_name) && PACKETS.key?(cipher_name)
@@ -1103,6 +1103,42 @@ module Transport
           end
         end
       end
+    end
+
+    def test_enqueue_aead_packet
+      opts = { shared: "123", digester: OpenSSL::Digest::SHA1, hash: "^&*" }
+      cipher = Net::SSH::Transport::CipherFactory.get('aes256-gcm@openssh.com', opts.merge(key: "abcabcabcabcabca", iv: "abcabcabcabc", encrypt: true))
+      hmac = Net::SSH::Transport::HMAC.get('aes256-gcm@openssh.com', "{}|", opts)
+      expected_packet = "\x00\x00\x00 \x13X5\x00\x0FM\v@E\x8C\x9F\"fk\x8A\x8B!\x95\x030Tz\xDB\x86\x9C\xE0\f\xB8\x0E\x05\b&\xE1\x8B\xDE\xED\xB2\xEE\xB3\xB25in\x8C\x12\xD7*\xF4"
+
+      stream.client.set cipher: cipher, hmac: hmac
+      stream.enqueue_packet(ssh_packet)
+      bytes = stream.instance_variable_get('@output').content
+      # The test ssh packet is 20 bytes long, padded until 32. Auth tag is 16 bytes long
+      # and packet length is 4 bytes length, so the ciphered payload should be 52 bytes long
+      assert_equal 52, bytes.bytesize
+      # After the 24 first bytes, the random padding takes place. So, the auth tag is unpredictable too
+      # Actually, the auth_tag mechanism is tested in #test_next_aead_packet
+      assert_equal expected_packet[0...24], bytes[0...24]
+      stream.cleanup
+    end
+
+    def test_next_aead_packet
+      opts = { shared: "123", digester: OpenSSL::Digest::SHA1, hash: "^&*" }
+      cipher = Net::SSH::Transport::CipherFactory.get('aes256-gcm@openssh.com', opts.merge(key: "abcabcabcabcabca", iv: "abcabcabcabc", decrypt: true))
+      hmac = Net::SSH::Transport::HMAC.get('aes256-gcm@openssh.com', "{}|", opts)
+      aead_ssh_packet = "\x00\x00\x00 \x13X5\x00\x0FM\v@E\x8C\x9F\"fk\x8A\x8B!\x95\x030Tz\xDB\x86\x9C\xE0\f\xB8\x0E\x05\b&\xE1\x8B\xDE\xED\xB2\xEE\xB3\xB25in\x8C\x12\xD7*\xF4"
+
+      stream.server.set cipher: cipher, hmac: hmac
+      stream.stubs(:recv).returns(aead_ssh_packet)
+      IO.stubs(:select).returns([[stream]])
+      packet = stream.next_packet(:nonblock)
+      assert_not_nil packet
+      assert_equal DEBUG, packet.type
+      assert packet[:always_display]
+      assert_equal "debugging", packet[:message]
+      assert_equal "", packet[:language]
+      stream.cleanup
     end
 
     private


### PR DESCRIPTION
A fork from https://github.com/net-ssh/net-ssh/pull/845

Add support for AEAD-AES256-GCM

Add support for AEAD-AES128-GCM

Adding test for aead ciphers

Add aes256-gcm cipher mode

Fixing exising tests